### PR TITLE
Escape user input and handle 404 for index.json

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -6,6 +6,8 @@ const WORD_REGEX = /\b(\w*)[\W|\s|\b]?/gm;
 async function initSearchIndex() {
   try {
     const response = await fetch("/index.json");
+    if (response.status !== 200) return;
+
     pagesIndex = await response.json();
     searchIndex = lunr(function () {
       this.field("title");
@@ -82,6 +84,8 @@ function getLunrSearchQuery(query) {
 }
 
 function getSearchResults(query) {
+  if (typeof searchIndex === "undefined") return [];
+
   return searchIndex.search(query).flatMap((hit) => {
     if (hit.ref == "undefined") return [];
     let pageMatch = pagesIndex.filter((page) => page.href === hit.ref)[0];
@@ -162,7 +166,8 @@ function createSearchResultBlurb(query, pageContent) {
 }
 
 function createQueryStringRegex(query) {
-  return query.split(" ").length == 1 ? `(${query})` : `(${query.split(" ").join("|")})`;
+  const escaped = RegExp.escape(query);
+  return escaped.split(" ").length == 1 ? `(${escaped})` : `(${escaped.split(" ").join("|")})`;
 }
 
 function tokenize(input) {
@@ -278,6 +283,13 @@ document.addEventListener("DOMContentLoaded", function () {
       button.addEventListener("click", () => handleClearSearchButtonClicked())
     );
 });
+
+if (!RegExp.escape) {
+  RegExp.escape = function(str) {
+    // $& means the whole matched string
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  };
+}
 
 if (!String.prototype.matchAll) {
   String.prototype.matchAll = function (regex) {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -284,10 +284,15 @@ document.addEventListener("DOMContentLoaded", function () {
     );
 });
 
-if (!RegExp.escape) {
+// RegExp.escape() polyfill
+//
+// For more see:
+// - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+// - https://github.com/benjamingr/RegExp.escape/issues/37
+if (!Object.prototype.hasOwnProperty.call(RegExp, 'escape')) {
   RegExp.escape = function(str) {
     // $& means the whole matched string
-    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return str.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
   };
 }
 


### PR DESCRIPTION
Hello, there are 2 fixes.

The first one is for the cases when there is no `index.json`.

The second fix is designed to protect RegExp from throwing an exception in case of entering characters that are used by the syntax of regular expressions.

<img width="849" alt="Screenshot 2022-07-10 at 15 03 39" src="https://user-images.githubusercontent.com/1256298/178146049-a81e015e-b623-450e-a75e-9015011b8235.png">
